### PR TITLE
Add link to magento coding standard repository

### DIFF
--- a/src/pages/guides/code-contributions/definition-of-done.md
+++ b/src/pages/guides/code-contributions/definition-of-done.md
@@ -20,7 +20,7 @@ The basic checklist used to evaluate if the DoD has been met is:
 -  All changes must be approved by reviewer.
 -  All changes must be covered by automated tests if possible.
 -  All functional changes should be documented.
--  All backward incompatible changes should be approved and covered by static tests if possible. Static tests should be delivered to the [magento-coding-standard][5] repository.
+-  All backward incompatible changes should be approved and covered by static tests if possible. Static tests should be delivered to the [magento-coding-standard](https://github.com/magento/magento-coding-standard) repository.
 -  TCO impact should be defined for all changes.
 
 The following sections provide additional details about each of these criteria:


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes nonexistent footnote reference ([5]) and links directly to [magento coding standard repo](https://github.com/magento/magento-coding-standard).

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/contributor/guides/code-contributions/definition-of-done/

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->


<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-contributor/blob/main/.github/CONTRIBUTING.md) for more information.
-->
