### PR TITLE
Update example of backwards compatibility policy to use explicitly nu…

### DIFF
--- a/src/pages/guides/code-contributions/backward-compatibility-policy.md
+++ b/src/pages/guides/code-contributions/backward-compatibility-policy.md
@@ -152,7 +152,7 @@ class ExistingClass
         \Old\Dependency\Interface $oldDependency,
         $oldRequiredConstructorParameter,
         $oldOptionalConstructorParameter = null,
-        \New\Dependency\Interface $newDependency = null
+        ?\New\Dependency\Interface $newDependency = null
     ) {
         ...
         $this->newDependency = $newDependency ?: ObjectManager::getInstance()->get(\New\Dependency\Interface::class);


### PR DESCRIPTION
…llable types (not doing this is deprecated since PHP 8.4)

## Purpose of this pull request

This pull request fixes the example in the backwards compatibility policy documentation page, to show in an example what the line above it says:
> Prefix the type name with a question mark when declaring a parameter with a null default value.

For some reason, the example shown doesn't follow this advise.
This becomes more important, now that Magento 2.4.8 will support PHP 8.4 and this syntax of using implicit nullable types with a default value of `null` [is now deprecated in PHP 8.4](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types) (this syntax is backwards compatible all the way back to PHP 7.1 and very old Magento versions, so there's no reason to wait with publishing this)

## Affected pages

- https://developer.adobe.com/commerce/contributor/guides/code-contributions/backward-compatibility-policy/#adding-a-constructor-parameter
