### PR TITLE
Fix GitHub Pages preview workflow

### DIFF
--- a/.github/workflows/github-pages-preview.yml
+++ b/.github/workflows/github-pages-preview.yml
@@ -25,6 +25,7 @@ jobs:
       PATH_PREFIX: ${{ github.event.repository.name }}
     steps:
       - name: Checkout content repo
+        id: checkout-content
         uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch || github.ref }}
@@ -63,7 +64,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version-file: "content/.nvmrc"
+          node-version-file: "content/.nvmrc"  # must match path: in step checkout-content
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/github-pages-preview.yml
+++ b/.github/workflows/github-pages-preview.yml
@@ -25,7 +25,7 @@ jobs:
       PATH_PREFIX: ${{ github.event.repository.name }}
     steps:
       - name: Checkout content repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch || github.ref }}
           path: content
@@ -49,21 +49,21 @@ jobs:
           echo "✓ Site path validated: $SITE_PATH (prefix: $SITE_PREFIX)"
 
       - name: Clone adp-devsite
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: AdobeDocs/adp-devsite
           path: adp-devsite
 
       - name: Clone devsite-runtime-connector
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: aemsites/devsite-runtime-connector
           path: devsite-runtime-connector
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "lts/jod"
+          node-version-file: ".nvmrc"
 
       - name: Install dependencies
         run: |
@@ -353,10 +353,10 @@ jobs:
           echo "✓ Build verification passed"
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: _site
 
@@ -372,4 +372,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/github-pages-preview.yml
+++ b/.github/workflows/github-pages-preview.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version-file: ".nvmrc"
+          node-version-file: "content/.nvmrc"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/github-pages-preview.yml
+++ b/.github/workflows/github-pages-preview.yml
@@ -65,6 +65,11 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version-file: "content/.nvmrc"  # must match path: in step checkout-content
+          cache: npm
+          cache-dependency-path: |
+            content/package-lock.json
+            adp-devsite/package-lock.json
+            devsite-runtime-connector/package-lock.json
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/github-pages-preview.yml
+++ b/.github/workflows/github-pages-preview.yml
@@ -79,14 +79,18 @@ jobs:
           (cd "$ROOT_DIR/content" && npm run dev > "$ROOT_DIR/content-server.log" 2>&1) &
           echo $! > /tmp/content.pid
           
-          # Start adp-devsite markup server (port 3000)
-          # Run node ./dev.mjs directly instead of npm run dev to avoid the concurrently wrapper,
-          # which would also launch dev:aem (conflicts with devsite-runtime-connector on port 3001)
-          # and dev:markup's trailing `open` call (macOS-only, kills the process tree on Linux).
+          # Start adp-devsite markup proxy (port 3000)
+          # Run node ./dev.mjs directly to avoid the npm run dev concurrently wrapper whose
+          # dev:markup script ends with `open http://localhost:3000` (macOS-only; fails on Linux
+          # and causes concurrently -k to kill the entire process group).
           (cd "$ROOT_DIR/adp-devsite" && node ./dev.mjs > "$ROOT_DIR/devsite-server.log" 2>&1) &
           echo $! > /tmp/devsite.pid
-          
-          # Start runtime connector (port 3001)
+
+          # Start AEM CLI (port 3001) — required by dev.mjs to proxy non-docs content
+          (cd "$ROOT_DIR/adp-devsite" && npx @adobe/aem-cli --no-open --port 3001 up > "$ROOT_DIR/aem-server.log" 2>&1) &
+          echo $! > /tmp/aem.pid
+
+          # Start runtime connector (port 3002)
           (cd "$ROOT_DIR/devsite-runtime-connector" && npm run dev > "$ROOT_DIR/connector-server.log" 2>&1) &
           echo $! > /tmp/connector.pid
           
@@ -95,7 +99,7 @@ jobs:
       - name: Wait for servers to be ready
         run: |
           echo "Waiting for servers..."
-          for port in 3000 3003; do
+          for port in 3000 3001 3003; do
             for i in {1..60}; do
               if curl -s "http://localhost:$port" > /dev/null 2>&1; then
                 echo "✓ Port $port is ready"
@@ -335,7 +339,7 @@ jobs:
       - name: Stop servers
         if: always()
         run: |
-          for pidfile in /tmp/content.pid /tmp/devsite.pid /tmp/connector.pid; do
+          for pidfile in /tmp/content.pid /tmp/devsite.pid /tmp/aem.pid /tmp/connector.pid; do
             if [ -f "$pidfile" ]; then
               kill $(cat "$pidfile") 2>/dev/null || true
             fi

--- a/.github/workflows/github-pages-preview.yml
+++ b/.github/workflows/github-pages-preview.yml
@@ -79,8 +79,11 @@ jobs:
           (cd "$ROOT_DIR/content" && npm run dev > "$ROOT_DIR/content-server.log" 2>&1) &
           echo $! > /tmp/content.pid
           
-          # Start adp-devsite (port 3000)
-          (cd "$ROOT_DIR/adp-devsite" && npm run dev > "$ROOT_DIR/devsite-server.log" 2>&1) &
+          # Start adp-devsite markup server (port 3000)
+          # Run node ./dev.mjs directly instead of npm run dev to avoid the concurrently wrapper,
+          # which would also launch dev:aem (conflicts with devsite-runtime-connector on port 3001)
+          # and dev:markup's trailing `open` call (macOS-only, kills the process tree on Linux).
+          (cd "$ROOT_DIR/adp-devsite" && node ./dev.mjs > "$ROOT_DIR/devsite-server.log" 2>&1) &
           echo $! > /tmp/devsite.pid
           
           # Start runtime connector (port 3001)

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -59,6 +59,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+
       - name: Run TOC validation
         run: npm run test:config
 
@@ -71,6 +76,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
 
       - name: Markdown lint
         run: npm run lint:md

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -40,7 +40,7 @@ jobs:
         id: filter
         run: |
           git fetch origin ${{ inputs.base_ref }}
-          CHANGED_FILES=$(git diff --name-only origin/${{ inputs.base_ref }}...HEAD)
+          CHANGED_FILES=$(git diff --name-only origin/${{ inputs.base_ref }}..HEAD)
           if echo "$CHANGED_FILES" | grep -q "^src/pages/"; then
             echo "run_validation=true" >> $GITHUB_OUTPUT
             echo "✅ Changes detected in src/pages/"

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -34,9 +34,7 @@ jobs:
       run_validation: ${{ steps.filter.outputs.run_validation }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+        uses: actions/checkout@v6
 
       - name: Check for src/pages changes
         id: filter
@@ -59,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run TOC validation
         run: npm run test:config
@@ -72,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Markdown lint
         run: npm run lint:md


### PR DESCRIPTION
## Purpose of this pull request

This PR fixes the GitHub Pages preview workflow and hardens PR validation so CI runs reliably on Linux runners.

- **GitHub Pages preview (`github-pages-preview.yml`):** Bump GitHub Actions to current versions (`checkout@v6`, `setup-node@v6`, `configure-pages@v6`, `upload-pages-artifact@v5`, `deploy-pages@v5`). Pin Node.js from `content/.nvmrc` and enable npm caching across the content, adp-devsite, and devsite-runtime-connector lockfiles that doubles the speed of the workflow run. Start the adp-devsite markup proxy with `node ./dev.mjs` instead of `npm run dev` so the macOS-only `open http://localhost:3000` step does not fail on Ubuntu and tear down the process group. Start the AEM CLI on port 3001 (required by `dev.mjs`), wait for ports 3000/3001/3003 before building, and clean up the AEM process on teardown.
- **PR validation (`validate-pr.yml`):** Bump `actions/checkout` to v6, add `setup-node` with `.nvmrc` for TOC and Markdown lint jobs, and change `git diff` from three-dot to two-dot syntax so `src/pages/` change detection matches commits on the branch without merge-base noise.

## Tests

Latest run: https://github.com/AdobeDocs/commerce-contributor/actions/runs/23615972877
Latest deployment: https://adobedocs.github.io/commerce-contributor/commerce/contributor/

## Affected pages

N/A — workflow and CI changes only; no documentation content under `src/pages/` is modified.

## Links to the public Commerce codebase

N/A